### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A secure Model Context Protocol (MCP) server for executing terminal commands. This server allows Large Language Models to safely execute commands within allowed paths.
 
+<a href="https://glama.ai/mcp/servers/xw5mtbhi5g"><img width="380" height="200" src="https://glama.ai/mcp/servers/xw5mtbhi5g/badge" alt="Terminal Server MCP server" /></a>
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [MCP Terminal Server](https://glama.ai/mcp/servers/xw5mtbhi5g) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/xw5mtbhi5g"><img width="380" height="200" src="https://glama.ai/mcp/servers/xw5mtbhi5g/badge" alt="Terminal Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.